### PR TITLE
Fix main 'vg-buffering.js' in bower.jon

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "videogular-buffering",
   "version": "1.0.0",
-  "main": "./buffering.js",
+  "main": "./vg-buffering.js",
   "dependencies": {
     "videogular": "latest"
   }


### PR DESCRIPTION
The Wiredep can not add files, because of the wrong file name in the mian bower.json
